### PR TITLE
Prepare v5.0.0 release for crates.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,16 @@ jobs:
     - name: Check fmt
       run: make fmt
 
+  doc:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install dependencies
+      run: sudo apt-get install -y cmake clang
+    - name: Check docs
+      run: make doc
+
   test-default:
     runs-on: ubuntu-latest
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "boring-rustls-provider"
-version = "0.0.1"
+version = "5.0.0"
 authors = ["Jan Rüth <boring-rustls-provider@djiehmail.com>"]
 edition = "2024"
 license = "MIT"
-description = "Boringssl rustls provider"
-publish = false
+description = "A BoringSSL-based rustls crypto provider with optional FIPS and post-quantum support"
+repository = "https://github.com/janrueth/boring-rustls-provider"
+readme = "Readme.md"
+keywords = ["tls", "rustls", "boringssl", "crypto", "fips"]
+categories = ["cryptography", "network-programming"]
 
 [features]
 default = []
@@ -40,8 +43,8 @@ logging = ["log"]
 
 [dependencies]
 aead = { version = "0.5", default-features = false, features = ["alloc"] }
-boring = { version = ">=5.1", default-features = false }
-boring-sys = { version = ">=5.1", default-features = false }
+boring = { version = ">=5.1, <6", default-features = false }
+boring-sys = { version = ">=5.1, <6", default-features = false }
 foreign-types = "0.5"
 log = { version = "0.4.4", optional = true }
 rustls = { version = "0.23", default-features = false }
@@ -61,3 +64,6 @@ webpki-roots = { version = "1.0" }
 [[example]]
 name = "client"
 required-features = ["logging"]
+
+[package.metadata.docs.rs]
+features = ["logging", "tls12", "mlkem"]

--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,7 @@ test:
 .PHONY: build
 build:
 	cargo build --all-targets $(CARGO_FEATURES)
+
+.PHONY: doc
+doc:
+	RUSTDOCFLAGS="-D missing_docs" cargo doc --no-deps -F logging,tls12,mlkem

--- a/Readme.md
+++ b/Readme.md
@@ -102,13 +102,6 @@ boring's `fips202205` compliance policy:
 - **Signature algorithms**: RSA PKCS#1 / PSS and ECDSA with P-256 or P-384 only
   (no P-521, Ed25519, or Ed448).
 
-## Workspace Structure
-
-| Crate | Purpose |
-|---|---|
-| `boring-rustls-provider` | The main rustls crypto provider. |
-| `examples` | Example client binary. |
-
 ## License
 
 MIT

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,30 @@
+//! A [`rustls`] [`CryptoProvider`] backed by [BoringSSL](https://github.com/cloudflare/boring).
+//!
+//! # Quick start
+//!
+//! ```no_run
+//! let config = rustls::ClientConfig::builder_with_provider(
+//!         boring_rustls_provider::provider().into(),
+//!     )
+//!     .with_safe_default_protocol_versions()
+//!     .unwrap()
+//!     .with_root_certificates(rustls::RootCertStore::empty())
+//!     .with_no_client_auth();
+//! ```
+//!
+//! # Features
+//!
+//! No features are enabled by default. The provider ships with TLS 1.3 support
+//! out of the box; additional capabilities are opt-in via feature flags:
+//!
+//! - **`fips`** — Build against FIPS-validated BoringSSL and restrict the
+//!   provider to FIPS-approved algorithms (SP 800-52r2). Implies `mlkem`.
+//! - **`mlkem`** — Enable the X25519MLKEM768 post-quantum hybrid key exchange
+//!   group.
+//! - **`tls12`** — Enable TLS 1.2 cipher suites.
+//! - **`logging`** — Enable debug logging via the [`log`](https://docs.rs/log)
+//!   crate.
+
 use std::sync::Arc;
 
 use helper::log_and_map;
@@ -17,12 +44,22 @@ mod hmac;
 mod kx;
 #[cfg(feature = "tls12")]
 mod prf;
+/// Private key loading and TLS signing operations.
 pub mod sign;
+/// TLS 1.2 cipher suite definitions (requires the `tls12` feature).
 #[cfg(feature = "tls12")]
 pub mod tls12;
+/// TLS 1.3 cipher suite definitions.
 pub mod tls13;
+/// Signature verification algorithms for certificate validation.
 pub mod verify;
 
+/// Returns a [`CryptoProvider`] with the default set of cipher suites and
+/// key exchange groups.
+///
+/// When the `fips` feature is enabled the provider is restricted to
+/// FIPS-approved algorithms and will **panic** if the underlying BoringSSL
+/// library is not running in FIPS mode.
 pub fn provider() -> CryptoProvider {
     #[cfg(feature = "fips")]
     {
@@ -40,6 +77,10 @@ pub fn provider() -> CryptoProvider {
     }
 }
 
+/// Returns a [`CryptoProvider`] using the given cipher suites.
+///
+/// When the `fips` feature is enabled, any non-FIPS cipher suites in
+/// `ciphers` are silently filtered out.
 pub fn provider_with_ciphers(ciphers: Vec<rustls::SupportedCipherSuite>) -> CryptoProvider {
     #[cfg(feature = "fips")]
     let ciphers = {

--- a/src/tls12.rs
+++ b/src/tls12.rs
@@ -22,6 +22,7 @@ static ALL_RSA_SCHEMES: &[SignatureScheme] = &[
 const PRF_SHA256: prf::PrfTls1WithDigest = prf::PrfTls1WithDigest(boring::nid::Nid::SHA256);
 const PRF_SHA384: prf::PrfTls1WithDigest = prf::PrfTls1WithDigest(boring::nid::Nid::SHA384);
 
+/// TLS 1.2 ECDHE-ECDSA with AES-128-GCM and SHA-256.
 pub static ECDHE_ECDSA_AES128_GCM_SHA256: Tls12CipherSuite = Tls12CipherSuite {
     common: rustls::crypto::CipherSuiteCommon {
         suite: rustls::CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
@@ -34,6 +35,7 @@ pub static ECDHE_ECDSA_AES128_GCM_SHA256: Tls12CipherSuite = Tls12CipherSuite {
     sign: ALL_ECDSA_SCHEMES,
 };
 
+/// TLS 1.2 ECDHE-RSA with AES-128-GCM and SHA-256.
 pub static ECDHE_RSA_AES128_GCM_SHA256: Tls12CipherSuite = Tls12CipherSuite {
     common: rustls::crypto::CipherSuiteCommon {
         suite: rustls::CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
@@ -46,6 +48,7 @@ pub static ECDHE_RSA_AES128_GCM_SHA256: Tls12CipherSuite = Tls12CipherSuite {
     sign: ALL_RSA_SCHEMES,
 };
 
+/// TLS 1.2 ECDHE-ECDSA with AES-256-GCM and SHA-384.
 pub static ECDHE_ECDSA_AES256_GCM_SHA384: Tls12CipherSuite = Tls12CipherSuite {
     common: rustls::crypto::CipherSuiteCommon {
         suite: rustls::CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
@@ -58,6 +61,7 @@ pub static ECDHE_ECDSA_AES256_GCM_SHA384: Tls12CipherSuite = Tls12CipherSuite {
     sign: ALL_ECDSA_SCHEMES,
 };
 
+/// TLS 1.2 ECDHE-RSA with AES-256-GCM and SHA-384.
 pub static ECDHE_RSA_AES256_GCM_SHA384: Tls12CipherSuite = Tls12CipherSuite {
     common: rustls::crypto::CipherSuiteCommon {
         suite: rustls::CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
@@ -70,6 +74,9 @@ pub static ECDHE_RSA_AES256_GCM_SHA384: Tls12CipherSuite = Tls12CipherSuite {
     sign: ALL_RSA_SCHEMES,
 };
 
+/// TLS 1.2 ECDHE-ECDSA with ChaCha20-Poly1305 and SHA-256.
+///
+/// Not available in FIPS mode.
 pub static ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256: Tls12CipherSuite = Tls12CipherSuite {
     common: rustls::crypto::CipherSuiteCommon {
         suite: rustls::CipherSuite::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
@@ -82,6 +89,9 @@ pub static ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256: Tls12CipherSuite = Tls12Ci
     sign: ALL_ECDSA_SCHEMES,
 };
 
+/// TLS 1.2 ECDHE-RSA with ChaCha20-Poly1305 and SHA-256.
+///
+/// Not available in FIPS mode.
 pub static ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256: Tls12CipherSuite = Tls12CipherSuite {
     common: rustls::crypto::CipherSuiteCommon {
         suite: rustls::CipherSuite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,

--- a/src/tls13.rs
+++ b/src/tls13.rs
@@ -2,6 +2,7 @@ use rustls::Tls13CipherSuite;
 
 use crate::{aead, hash, hkdf};
 
+/// TLS 1.3 AES-128-GCM with SHA-256.
 pub static AES_128_GCM_SHA256: Tls13CipherSuite = Tls13CipherSuite {
     common: rustls::crypto::CipherSuiteCommon {
         suite: rustls::CipherSuite::TLS13_AES_128_GCM_SHA256,
@@ -13,6 +14,7 @@ pub static AES_128_GCM_SHA256: Tls13CipherSuite = Tls13CipherSuite {
     quic: Some(&aead::Aead::<aead::aes::Aes128>::DEFAULT),
 };
 
+/// TLS 1.3 AES-256-GCM with SHA-384.
 pub static AES_256_GCM_SHA384: Tls13CipherSuite = Tls13CipherSuite {
     common: rustls::crypto::CipherSuiteCommon {
         suite: rustls::CipherSuite::TLS13_AES_256_GCM_SHA384,
@@ -24,6 +26,9 @@ pub static AES_256_GCM_SHA384: Tls13CipherSuite = Tls13CipherSuite {
     quic: Some(&aead::Aead::<aead::aes::Aes256>::DEFAULT),
 };
 
+/// TLS 1.3 ChaCha20-Poly1305 with SHA-256.
+///
+/// Not available in FIPS mode.
 pub static CHACHA20_POLY1305_SHA256: Tls13CipherSuite = Tls13CipherSuite {
     common: rustls::crypto::CipherSuiteCommon {
         suite: rustls::CipherSuite::TLS13_CHACHA20_POLY1305_SHA256,

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -4,6 +4,12 @@ pub(crate) mod ec;
 pub(crate) mod ed;
 pub(crate) mod rsa;
 
+/// All supported signature verification algorithms.
+///
+/// Includes RSA (PKCS#1 v1.5 and PSS), ECDSA (P-256, P-384, P-521),
+/// Ed25519, and Ed448.
+///
+/// For the FIPS-restricted subset see [`ALL_FIPS_ALGORITHMS`].
 #[allow(unused)]
 pub static ALL_ALGORITHMS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms {
     all: &[


### PR DESCRIPTION
Add required crates.io metadata (repository, readme, keywords, categories) and improve the package description. Set version to 5.0.0 to track the boring crate's major version. Tighten boring/boring-sys dependency bounds to >=5.1, <6 to prevent silent breakage on a future major release. Remove the stale workspace structure section from the readme.

Add documentation for all public API items: crate root, public modules (sign, tls12, tls13, verify), entry-point functions (provider, provider_with_ciphers), all cipher suite statics, and the ALL_ALGORITHMS verification table. The crate now passes cargo doc with -W missing_docs.